### PR TITLE
refactor: make AuthService instance-based with injectable repository

### DIFF
--- a/src/app/api/register/route.ts
+++ b/src/app/api/register/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 
 import { APP_CONFIG } from "@app/lib/config";
+import { UserRepository } from "@app/lib/repositories";
 import { AuthService } from "@app/lib/services";
 
 const registerSchema = z.object({
@@ -22,12 +23,14 @@ const registerSchema = z.object({
   currency: z.string().optional(),
 });
 
+const authService = new AuthService(new UserRepository());
+
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
     const validatedData = registerSchema.parse(body);
 
-    const user = await AuthService.createUser(validatedData);
+    const user = await authService.createUser(validatedData);
 
     return NextResponse.json(
       {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 
 import { APP_CONFIG } from "@app/lib/config";
 import { env } from "@app/lib/env/env.server";
+import { UserRepository } from "@app/lib/repositories";
 import { AuthService } from "@app/lib/services";
 
 const loginSchema = z.object({
@@ -15,6 +16,8 @@ const loginSchema = z.object({
       `Password must be at least ${APP_CONFIG.validation.password.minLength} characters`,
     ),
 });
+
+const authService = new AuthService(new UserRepository());
 
 export const authOptions: NextAuthOptions = {
   providers: [
@@ -32,7 +35,7 @@ export const authOptions: NextAuthOptions = {
           }
 
           const validatedCredentials = loginSchema.parse(credentials);
-          const user = await AuthService.authenticateUser(validatedCredentials);
+          const user = await authService.authenticateUser(validatedCredentials);
 
           return user;
         } catch (error) {

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -1,2 +1,2 @@
-export type { AuthenticateUserData, CreateUserData } from "./auth.service";
+export type { AuthenticateUserData, CreateUserData, IUserRepository } from "./auth.service";
 export { AuthService } from "./auth.service";


### PR DESCRIPTION
## Summary
- refactor AuthService into an injectable class
- update auth API route and NextAuth callback to use service instance

## Testing
- `pnpm lint`
- `pnpm type-check`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6890baa1e548832db0949fec63db3185