### PR TITLE
feat(auth): reuse register schema across client and API

### DIFF
--- a/src/app/api/register/route.ts
+++ b/src/app/api/register/route.ts
@@ -1,27 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 
-import { APP_CONFIG } from "@app/lib/config";
+import { registerSchema } from "@app/features/auth";
 import { UserRepository } from "@app/lib/repositories";
 import { AuthService } from "@app/lib/services";
-
-const registerSchema = z.object({
-  name: z
-    .string()
-    .min(
-      APP_CONFIG.validation.name.minLength,
-      `Name must be at least ${APP_CONFIG.validation.name.minLength} characters`,
-    ),
-  email: z.email("Invalid email format"),
-  password: z
-    .string()
-    .min(
-      APP_CONFIG.validation.password.minLength,
-      `Password must be at least ${APP_CONFIG.validation.password.minLength} characters`,
-    ),
-  defaultHourlyRate: z.number().min(APP_CONFIG.validation.hourlyRate.min).optional(),
-  currency: z.string().optional(),
-});
 
 const authService = new AuthService(new UserRepository());
 

--- a/src/features/auth/schemas/auth.schemas.ts
+++ b/src/features/auth/schemas/auth.schemas.ts
@@ -12,7 +12,7 @@ export const loginSchema = z.object({
     ),
 });
 
-export const registerSchema = z.object({
+const registerSchema = z.object({
   name: z
     .string()
     .min(
@@ -34,3 +34,5 @@ export const registerSchema = z.object({
 
 export type LoginFormData = z.infer<typeof loginSchema>;
 export type RegisterFormData = z.infer<typeof registerSchema>;
+
+export { registerSchema };


### PR DESCRIPTION
## Summary
- export `registerSchema` for external reuse
- reuse shared `registerSchema` in registration API

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_e_6890c542aae0832daf0d176845b1f71a