### PR TITLE
refactor: use shared auth service instance

### DIFF
--- a/src/app/api/register/route.ts
+++ b/src/app/api/register/route.ts
@@ -2,8 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 
 import { APP_CONFIG } from "@app/lib/config";
-import { UserRepository } from "@app/lib/repositories";
-import { AuthService } from "@app/lib/services";
+import { authService } from "@app/lib/services";
 
 const registerSchema = z.object({
   name: z
@@ -22,8 +21,6 @@ const registerSchema = z.object({
   defaultHourlyRate: z.number().min(APP_CONFIG.validation.hourlyRate.min).optional(),
   currency: z.string().optional(),
 });
-
-const authService = new AuthService(new UserRepository());
 
 export async function POST(request: NextRequest) {
   try {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,8 +4,7 @@ import { z } from "zod";
 
 import { APP_CONFIG } from "@app/lib/config";
 import { env } from "@app/lib/env/env.server";
-import { UserRepository } from "@app/lib/repositories";
-import { AuthService } from "@app/lib/services";
+import { authService } from "@app/lib/services";
 
 const loginSchema = z.object({
   email: z.email("Invalid email format"),
@@ -16,8 +15,6 @@ const loginSchema = z.object({
       `Password must be at least ${APP_CONFIG.validation.password.minLength} characters`,
     ),
 });
-
-const authService = new AuthService(new UserRepository());
 
 export const authOptions: NextAuthOptions = {
   providers: [

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -1,2 +1,8 @@
+import { UserRepository } from "../repositories";
+
+import { AuthService } from "./auth.service";
+
 export type { AuthenticateUserData, CreateUserData, IUserRepository } from "./auth.service";
-export { AuthService } from "./auth.service";
+export { AuthService };
+
+export const authService = new AuthService(new UserRepository());


### PR DESCRIPTION
## Summary
- create shared `authService` instance in services
- use the shared auth service in auth and registration routes

## Testing
- `pnpm lint`
- `pnpm type-check`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6890c543c754832d8dc2d7c62e123a0a