### PR TITLE
refactor: unify user creation types

### DIFF
--- a/src/lib/repositories/index.ts
+++ b/src/lib/repositories/index.ts
@@ -1,3 +1,3 @@
 export { BaseRepository } from "./base.repository";
-export type { CreateUserInput, UserPublicData } from "./user.repository";
 export { UserRepository } from "./user.repository";
+export type { UserCreate, UserPublicData } from "./user.types";

--- a/src/lib/repositories/user.repository.ts
+++ b/src/lib/repositories/user.repository.ts
@@ -1,23 +1,7 @@
 import type { User } from "@prisma/client";
 
 import { BaseRepository } from "./base.repository";
-
-export interface CreateUserInput {
-  name: string;
-  email: string;
-  password: string;
-  defaultHourlyRate: number;
-  currency: string;
-}
-
-export interface UserPublicData {
-  id: string;
-  name: string;
-  email: string;
-  defaultHourlyRate: number;
-  currency: string;
-  createdAt: Date;
-}
+import type { UserCreate, UserPublicData } from "./user.types";
 
 export class UserRepository extends BaseRepository {
   findByEmail(email: string): Promise<User | null> {
@@ -36,7 +20,7 @@ export class UserRepository extends BaseRepository {
     );
   }
 
-  create(data: CreateUserInput): Promise<UserPublicData> {
+  create(data: Required<UserCreate>): Promise<UserPublicData> {
     return this.execute("create", () =>
       this.db.user.create({
         data: {
@@ -58,7 +42,7 @@ export class UserRepository extends BaseRepository {
     );
   }
 
-  update(id: string, data: Partial<CreateUserInput>): Promise<UserPublicData> {
+  update(id: string, data: Partial<UserCreate>): Promise<UserPublicData> {
     return this.execute("update", () =>
       this.db.user.update({
         where: { id },

--- a/src/lib/repositories/user.types.ts
+++ b/src/lib/repositories/user.types.ts
@@ -1,0 +1,16 @@
+export interface UserCreate {
+  name: string;
+  email: string;
+  password: string;
+  defaultHourlyRate?: number;
+  currency?: string;
+}
+
+export interface UserPublicData {
+  id: string;
+  name: string;
+  email: string;
+  defaultHourlyRate: number;
+  currency: string;
+  createdAt: Date;
+}

--- a/src/lib/services/auth.service.ts
+++ b/src/lib/services/auth.service.ts
@@ -2,15 +2,7 @@ import type { User } from "@prisma/client";
 import bcrypt from "bcryptjs";
 
 import { APP_CONFIG } from "@app/lib/config";
-import { type CreateUserInput, type UserPublicData } from "@app/lib/repositories";
-
-export interface CreateUserData {
-  name: string;
-  email: string;
-  password: string;
-  defaultHourlyRate?: number;
-  currency?: string;
-}
+import { type UserCreate, type UserPublicData } from "@app/lib/repositories";
 
 export interface AuthenticateUserData {
   email: string;
@@ -19,14 +11,14 @@ export interface AuthenticateUserData {
 
 export interface IUserRepository {
   existsByEmail(email: string): Promise<boolean>;
-  create(data: CreateUserInput): Promise<UserPublicData>;
+  create(data: Required<UserCreate>): Promise<UserPublicData>;
   findByEmail(email: string): Promise<User | null>;
 }
 
 export class AuthService {
   constructor(private readonly userRepository: IUserRepository) {}
 
-  async createUser(data: CreateUserData) {
+  async createUser(data: UserCreate) {
     const { name, email, password, defaultHourlyRate, currency } = data;
 
     const userExists = await this.userRepository.existsByEmail(email);
@@ -37,7 +29,7 @@ export class AuthService {
 
     const hashedPassword = await bcrypt.hash(password, 12);
 
-    const userData: CreateUserInput = {
+    const userData: Required<UserCreate> = {
       name,
       email,
       password: hashedPassword,

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -1,2 +1,2 @@
-export type { AuthenticateUserData, CreateUserData, IUserRepository } from "./auth.service";
+export type { AuthenticateUserData, IUserRepository } from "./auth.service";
 export { AuthService } from "./auth.service";


### PR DESCRIPTION
## Summary
- create shared `UserCreate` type and relocate `UserPublicData`
- refactor AuthService and UserRepository to leverage shared type
- expose new user types via repository index

## Testing
- `pnpm lint`
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_e_6890c559a2a4832d90553cb3c371a078